### PR TITLE
fix: README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ void main() {
         ),
 
         /// Configuration for the `Done` text button.
-        doneConfig: NextConfig.copyWith(
+        doneConfig: DoneConfig.copyWith(
             text: 'DONE'
         ),
 


### PR DESCRIPTION
DoneConfig is mistyped as NextConfig in default configuration section of the README which leads to an error when copy pasted.