### PR TITLE
[Feat] Add an ability to show on top of all Overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ FeaturesTour(
         quadrantAlignment: QuadrantAlignment.bottom,
         // Alignment of the `introduce` widget in the quadrant rectangle
         alignment: Alignment.topCenter,
+        // Show on top all other overlays
+        useRootOverlay: false,
     ),
 
     /// Config for the next button, this button will move to the next widget base on its' index.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ FeaturesTour(
         quadrantAlignment: QuadrantAlignment.bottom,
         // Alignment of the `introduce` widget in the quadrant rectangle
         alignment: Alignment.topCenter,
-        // Show on top all other overlays
+        // Show the tour above all other overlays
         useRootOverlay: false,
     ),
 

--- a/lib/src/features_tour.dart
+++ b/lib/src/features_tour.dart
@@ -370,7 +370,10 @@ class FeaturesTour extends StatelessWidget {
         ),
       );
     });
-    Overlay.of(_context).insert(overlayEntry);
+    Overlay.of(
+      _context,
+      rootOverlay: introduceConfig.useRootOverlay,
+    ).insert(overlayEntry);
 
     /// Closed by the `barrierDismissible`.
     final result = (await completer.future) ?? IntroduceResult.next;

--- a/lib/src/models/introduce_config.dart
+++ b/lib/src/models/introduce_config.dart
@@ -28,12 +28,18 @@ class IntroduceConfig {
   /// to make it visible on the dark background.
   final bool applyDarkTheme;
 
+  /// If `useRootOverlay` is set to true, the tour will show above all other [Overlay]s.
+  ///
+  /// This method can be expensive (it walks the element tree).
+  final bool useRootOverlay;
+
   const IntroduceConfig._({
     this.backgroundColor = Colors.black87,
     this.padding = const EdgeInsets.all(20.0),
     this.quadrantAlignment,
     this.alignment,
     this.applyDarkTheme = true,
+    this.useRootOverlay = false,
   });
 
   /// Create a new IntroduceConfig base on [global] values.
@@ -43,6 +49,7 @@ class IntroduceConfig {
     QuadrantAlignment? quadrantAlignment,
     Alignment? alignment,
     bool? applyDarkTheme,
+    bool? useRootOverlay,
   }) {
     return global.copyWith(
       backgroundColor: backgroundColor,
@@ -50,6 +57,7 @@ class IntroduceConfig {
       alignment: alignment,
       quadrantAlignment: quadrantAlignment,
       applyDarkTheme: applyDarkTheme,
+      useRootOverlay: useRootOverlay,
     );
   }
 
@@ -71,6 +79,7 @@ class IntroduceConfig {
     QuadrantAlignment? quadrantAlignment,
     Duration? animationDuration,
     bool? applyDarkTheme,
+    bool? useRootOverlay,
   }) {
     return IntroduceConfig._(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -78,6 +87,7 @@ class IntroduceConfig {
       alignment: alignment ?? this.alignment,
       quadrantAlignment: quadrantAlignment ?? this.quadrantAlignment,
       applyDarkTheme: applyDarkTheme ?? this.applyDarkTheme,
+      useRootOverlay: useRootOverlay ?? this.useRootOverlay,
     );
   }
 }


### PR DESCRIPTION
Fixes #4 

Add a `useRootOverlay` parameter to the `IntroduceConfig` with a `false` value by default. If this parameter is true, the introduction will show on top of all overlays.